### PR TITLE
Adds handling for a format= argument for plugins that can support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ implementation returns:
 Returns an array or object that defines valid scopes for the target search engine. Because many search engines do not support scopes, the provided implementation returns
 an empty object. Optional.
 
+##### formats()
+
+Returns an array or object the defines valid formats or material types for the target search engine. Because many search engines do not support formats, the provided
+implementation returns an empty object. Optional.
+
 ##### emptySearchWarning
 
 This property provides a string warning for a missing search expression. The provided default is 'Missing or empty search expression.' Optional.

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = stampit()
       'query': {
       },
     };
-    ['target', 'search', 'scope', 'field'].map(param => {
+    ['target', 'search', 'scope', 'field', 'format'].map(param => {
       logEvent.query[param] = (ctx.request.query[param])
         ? ctx.request.query[param]
         : '';

--- a/test/factory.js
+++ b/test/factory.js
@@ -59,10 +59,10 @@ test('factory uriFor()', co(function *(t) {
     bar: barPlugin,
   });
 
-  let [fooWarning, fooUri] = yield factory.uriFor({target: 'FOO', search: 'manchoo', scope: 'business', field: 'author'});
+  let [fooWarning, fooUri] = yield factory.uriFor({target: 'FOO', search: 'manchoo', scope: 'business', field: 'author', format: 'audio'});
   t.equal(
     fooUri.href(),
-    'https://foo.com?search=manchoo&scope=business&field=author',
+    'https://foo.com?search=manchoo&scope=business&field=author&format=audio',
     'expected href for target "FOO"'
   );
 

--- a/test/fixtures/foo-plugin.js
+++ b/test/fixtures/foo-plugin.js
@@ -18,7 +18,7 @@ const foo = stampit()
       article: 'Journal Articles',
       audio: 'Audio recordings',
       video: 'Video recordings',
-    }
+    };
   },
   baseUri () {
     return URI({

--- a/test/fixtures/foo-plugin.js
+++ b/test/fixtures/foo-plugin.js
@@ -12,6 +12,14 @@ const foo = stampit()
       music: 'Music Library',
     };
   },
+  formats () {
+    return {
+      book: 'Books',
+      article: 'Journal Articles',
+      audio: 'Audio recordings',
+      video: 'Video recordings',
+    }
+  },
   baseUri () {
     return URI({
       protocol: 'https',

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -43,6 +43,10 @@ test('plugin invalid field args', function (t) {
   tester.invalidFieldArgs(t, plugin, 'https://foo.com?search=darwin');
 });
 
+test('plugin invalid format args', function (t) {
+  tester.invalidFormatArgs(t, plugin, 'https://foo.com?search=darwin');
+});
+
 test('plugin invalid scope args', function (t) {
   tester.invalidScopeArgs(t, plugin, 'https://foo.com?search=darwin');
 });

--- a/uri-factory/index.js
+++ b/uri-factory/index.js
@@ -12,7 +12,7 @@ module.exports = stampit()
         reject(new InvalidArgumentError(`no plugin defined for target '${target}'`));
       }
       const plugin = factory[target];
-      resolve(plugin.uriFor(params.search, params.scope, params.field));
+      resolve(plugin.uriFor(params.search, params.scope, params.field, params.format));
     });
   },
 }).init(function () {

--- a/uri-factory/plugin-tester.js
+++ b/uri-factory/plugin-tester.js
@@ -73,10 +73,17 @@ module.exports = stampit()
     t.end();
   },
 
+  invalidFormatArgs: function (t, plugin, expectedHref) {
+    const [warning, uri] = plugin.uriFor('darwin', 'bogus', null);
+    t.equal(uri.href(), expectedHref, 'expected href (' + expectedHref + ') for an invalid "format" value...');
+    t.equal(warning, 'Unrecognized format: "bogus"', '...and expected warning for an invalid "format" value');
+    t.end();
+  },
+
   validSearchArgs: co(function *(t, plugin, testCases, getResultCount) {
     for (let expectedHref in testCases) {
       let args = testCases[expectedHref];
-      let [warning, uri] = plugin.uriFor(args.search, args.scope, args.field);
+      let [warning, uri] = plugin.uriFor(args.search, args.scope, args.field, args.format);
 
       let href = uri.href();
       t.equal(href, expectedHref, 'expectedHref (' + expectedHref + ') for valid args search: ' + args.search + ', scope: ' + args.scope + ', field: ' + args.field + '...');

--- a/uri-factory/plugin-tester.js
+++ b/uri-factory/plugin-tester.js
@@ -74,7 +74,7 @@ module.exports = stampit()
   },
 
   invalidFormatArgs: function (t, plugin, expectedHref) {
-    const [warning, uri] = plugin.uriFor('darwin', 'bogus', null);
+    const [warning, uri] = plugin.uriFor('darwin', null, null, 'bogus');
     t.equal(uri.href(), expectedHref, 'expected href (' + expectedHref + ') for an invalid "format" value...');
     t.equal(warning, 'Unrecognized format: "bogus"', '...and expected warning for an invalid "format" value');
     t.end();
@@ -86,7 +86,7 @@ module.exports = stampit()
       let [warning, uri] = plugin.uriFor(args.search, args.scope, args.field, args.format);
 
       let href = uri.href();
-      t.equal(href, expectedHref, 'expectedHref (' + expectedHref + ') for valid args search: ' + args.search + ', scope: ' + args.scope + ', field: ' + args.field + '...');
+      t.equal(href, expectedHref, 'expectedHref (' + expectedHref + ') for valid args search: ' + args.search + ', scope: ' + args.scope + ', field: ' + args.field + ', format: ' + args.format + '...');
       t.false(warning, '...and no warning returned...');
 
       if (this.runIntegrationTests) {

--- a/uri-factory/plugin.js
+++ b/uri-factory/plugin.js
@@ -90,7 +90,7 @@ module.exports = stampit()
       if (format in this.formats()) {
         params['format'] = format;
       } else {
-        warnings.push(this.badFormatWarning + `"${format}}"`);
+        warnings.push(this.badFormatWarning + `"${format}"`);
       }
     }
 

--- a/uri-factory/plugin.js
+++ b/uri-factory/plugin.js
@@ -7,6 +7,7 @@ module.exports = stampit()
   emptySearchWarning: 'Missing or empty search expression.',
   badScopeWarning: 'Unrecognized scope: ',
   badFieldWarning: 'Unrecognized field: ',
+  badFormatWarning: 'Unrecognized format: ',
 })
 .methods({
   // Though some of these methods will likely do nothing except return objects
@@ -33,6 +34,18 @@ module.exports = stampit()
     */
   },
 
+  formats () {
+    return {};
+    /* example override implementation:
+    {
+      audio: 'Audio recordings',
+      books: 'Books',
+      scores: 'Music scores'
+      video: 'Video recordings',
+    }
+    */
+  },
+
   baseUri () {
     return URI();
     /* example override implementation:
@@ -47,7 +60,7 @@ module.exports = stampit()
     return this.baseUri();
   },
 
-  uriFor (search, scope, field) {
+  uriFor (search, scope, field, format) {
     if (!search) {
       return [
         this.emptySearchWarning,
@@ -70,6 +83,14 @@ module.exports = stampit()
         params['field'] = field;
       } else {
         warnings.push(this.badFieldWarning + `"${field}"`);
+      }
+    }
+
+    if (format) {
+      if (format in this.formats()) {
+        params['format'] = format;
+      } else {
+        warnings.push(this.badFormatWarning + `"${format}}"`);
       }
     }
 


### PR DESCRIPTION
General support for a `formats()` plugin method returning an array or object of supported formats, implemented identically to `scope,field`

Note: an equivalent PR open in https://github.com/UMNLibraries/janus-uri-factory-plugins/ depends on this one to first be merged for TravisCI builds to pass.