### PR TITLE
Specifies stable koa dependencies, fixes #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "bunyan": "^1.8.1",
-    "koa": "next",
+    "koa": "^2.6.1",
     "koa-convert": "^1.2.0",
-    "koa-favicon": "next",
-    "koa-router": "next",
+    "koa-favicon": "^2.0.1",
+    "koa-router": "^7.4.0",
     "koa-session": "^3.3.1",
     "require-all": "^2.0.0",
     "stampit": "^2.1.1",


### PR DESCRIPTION
Sets major major version locked koa dependencies to avoid 8.0/prerelease/alpha. Partially addresses #9, does not modify node version though.