### PR TITLE
Fixes calls to init() in stampit 4.3.1.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,15 +65,17 @@ module.exports = stampit()
       return logEvent
     }
   })
-  .init(function () {
-    const factory = require(path.resolve(__dirname, 'uri-factory/'))(this.uriFactoryPlugins)
+  .init(function (params) {
+    const factory = require(path.resolve(__dirname, 'uri-factory/'))(params.uriFactoryPlugins)
     const sessionId = this.sessionId
     const redirectLogger = this.redirectLogger()
+    this.errorLog = params.errorLog
     const errorLogger = this.errorLogger()
+    this.redirectLog = params.redirectLog
     const defaultRedirectLogEvent = this.defaultRedirectLogEvent
     const redirectLogEvent = this.redirectLogEvent
 
-    router.get(this.uriPathPrefix, async function redirect (ctx, next) {
+    router.get(params.uriPathPrefix, async function redirect (ctx, next) {
       await next()
       const [warning, uri] = await factory.uriFor(ctx.request.query)
       ctx.status = 302


### PR DESCRIPTION
The version of stampit, 4.3.1, which we use in this release, no longer
automatically sets properties on this based on object keys passed
to the constructor init(). We now explicitly capture those properties
in params, and explicitly set the analogous properties on this.