### PR TITLE
WIP Support for ?params=target|scope|format input, replacing apache rewrites

### DIFF
--- a/test/factory.js
+++ b/test/factory.js
@@ -79,6 +79,41 @@ test('factory uriFor()', async function (t) {
     'all supported param names are case-insensitive'
   )
 
+  fooUriResult = await factory.uriFor({ params: 'foo|music|audio', search: 'palestrina' })
+  t.equal(
+    fooUriResult[1].href(),
+    'https://foo.com?search=palestrina&scope=music&format=audio',
+    'pipe-delimited params= are supported'
+  )
+
+  fooUriResult = await factory.uriFor({ params: 'foo||audio', search: 'palestrina' })
+  t.equal(
+    fooUriResult[1].href(),
+    'https://foo.com?search=palestrina&format=audio',
+    'pipe-delimited params= may omit values between delimiters'
+  )
+
+  fooUriResult = await factory.uriFor({ params: 'foo', search: 'palestrina' })
+  t.equal(
+    fooUriResult[1].href(),
+    'https://foo.com?search=palestrina',
+    'pipe-delimited params= may omit all delimiters, supplying only target'
+  )
+
+  fooUriResult = await factory.uriFor({ params: 'foo|music|audio', search: 'palestrina', target: 'bar', format: 'video' })
+  t.equal(
+    fooUriResult[1].href(),
+    'https://foo.com?search=palestrina&scope=music&format=audio',
+    'pipe-delimited params= override individually supplied query values'
+  )
+
+  fooUriResult = await factory.uriFor({ ParAmS: 'foo|music|audio', search: 'palestrina' })
+  t.equal(
+    fooUriResult[1].href(),
+    'https://foo.com?search=palestrina&scope=music&format=audio',
+    'pipe-delimited params= is case-insensitive'
+  )
+
   let barUriResult = await factory.uriFor({ target: 'bar', search: 'baz' })
   t.equal(
     barUriResult[1].href(),

--- a/uri-factory/index.js
+++ b/uri-factory/index.js
@@ -4,12 +4,15 @@ const stampit = require('stampit')
 
 module.exports = stampit()
   .props({
-    supportedQueryParamNames: ['target', 'search', 'scope', 'field', 'format']
+    // Special param "params=" pipe delimited targetvalue|scopevalue|formatvalue
+    supportedQueryParamNames: ['target', 'search', 'scope', 'field', 'format', 'params']
   })
   .methods({
 
     normalizeQueryParams (rawParams, supportedOnly = false) {
       const params = {}
+      const delimParamsKey = Object.keys(rawParams).find(k => k.toLowerCase() === 'params')
+
       for (const [key, value] of Object.entries(rawParams)) {
         const lcKey = key.toLowerCase()
         if (this.supportedQueryParamNames.includes(lcKey)) {
@@ -17,6 +20,18 @@ module.exports = stampit()
         } else if (!supportedOnly) {
           params[key] = value
         }
+      }
+      // Take all values from delimited params if present, supercede parameters other than search
+      // if they had also been present
+      if (delimParamsKey) {
+        [
+          params.target,
+          params.scope,
+          params.format
+        ] = rawParams[delimParamsKey].split('|').map(v => v.replace(/\s*$/, ''))
+        // Prior loop sets the delimited string when not in supportedOnly mode
+        // Eliminate it
+        delete params[delimParamsKey]
       }
       return params
     },


### PR DESCRIPTION
We need to eliminate an Apache web server mod_rewrite dependency whereby apache accepts `?params=targetval|scopeval|formatval` expanding into Janus `?target=targetval&scope=scopeval&format=formatval`

This will add native support for the pipe-delimited `params=` parameter

Implementation notes:
* For compatibility with how it works under mod_rewrite, if BOTH a `params=` string and other individual Janus parameters are present, the individual parameters are discarded/overwritten by the delimited `params=` string
* In code, they will be _literally_ overwritten. Janus params are parsed & populated first, then delimited `params=` is expanded, overwriting them including nulling them out if they were empty in the delimited string.

Target completion/merge: Spring 2025.