### PR TITLE
 /healthcheck URI just returns a 200/ok for cloud service monitoring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Install with npm. In package.json, include something like...
   "dependencies": {
     "@nihiliad/janus": "^2.0.0"
   }
-````
+```
 
 ...where version based on the `version` value in this project's `package.json`. Then `npm install`.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ http://primo.lib.umn.edu/primo_library/libweb/action/dlSearch.do?institution=TWI
 	- [Sessions](#sessions)
 	- [Logging](#logging)
 		- [redirectLogEvent(ctx)](#redirectlogeventctx)
+- [Health Check URI](#health-check-uri)
 - [Install](#install)
 - [Test](#test)
 	- [Lint](#lint)
@@ -220,7 +221,7 @@ Janus uses [koa-session](https://www.npmjs.com/package/koa-session) to assign ea
 
 One way to override this method when invoking Janus:
 
-```javascript 
+```javascript
 const plugins = require('your-plugins');
 const janus = require('@nihiliad/janus').methods({
   sessionId (ctx) {
@@ -229,7 +230,7 @@ const janus = require('@nihiliad/janus').methods({
         // generate your session id
       );
     });
-  },  
+  },
 });
 const app = janus({
   uriFactoryPlugins: plugins,
@@ -264,6 +265,15 @@ const app = janus({
 app.listen(3000);
 ```
 
+## Health Check URI
+The application will return a basic `200 ok` at a URI under `uriPathPrefix`, e.g.
+```
+// uriPathPrefix = '/janus'
+
+GET /janus/healthcheck
+200 ok
+```
+
 ## Install
 
 Install with npm. In package.json, include something like...
@@ -272,7 +282,7 @@ Install with npm. In package.json, include something like...
   "dependencies": {
     "@nihiliad/janus": "^2.0.0"
   }
-```
+````
 
 ...where version based on the `version` value in this project's `package.json`. Then `npm install`.
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,12 @@ export default stampit()
       }
     })
 
+    // Basic 200 response to validate the node app works
+    // No logging redirect/error
+    router.get(params.uriPathPrefix + '/healthcheck', function(ctx, next) {
+      ctx.body = 'ok'
+    })
+
     const app = new Koa()
     app
       .use(favicon(this.favicon))


### PR DESCRIPTION
This adds a URI under the prefix path `/healthcheck` that merely returns 200/ok without invoking the URI factory. It is to be used by monitoring services that are only concerned with whether Node is responding to inputs but need not form a redirect.

e.g.

*  `http://localhost:1337/healthcheck` if `uriPathPrefix == '/'`
*  `http://localhost:1337/janus/healthcheck` if `uriPathPrefix == '/janus'`

It might be more ideal for this to be an implementation detail in janus-deploy instead, but the router isn't expose there to add additional routes at this time.